### PR TITLE
set intent to null after cancelling

### DIFF
--- a/com.on.relax.your.eyes.droid/AlarmImpl.cs
+++ b/com.on.relax.your.eyes.droid/AlarmImpl.cs
@@ -44,6 +44,7 @@ namespace com.on.relax.your.eyes.droid
         public void CancelSingleAlarm()
         {
             GetLazyAlarmIntent().Cancel();
+            _alarmIntent = null;
         }
     }
 }


### PR DESCRIPTION
in order to allow restart the alarm after cancelling, the intent is set to null
the old intent is garbage-collected
the new intent produces a new alarm and the app works properly