### PR TITLE
Feature/robust alarm clock

### DIFF
--- a/com.on.relax.your.eyes.droid/AlarmImpl.cs
+++ b/com.on.relax.your.eyes.droid/AlarmImpl.cs
@@ -23,7 +23,7 @@ namespace com.on.relax.your.eyes.droid
             return _alarmManager;
         }
 
-        private PendingIntent GetLazyAlarmIntent()
+        private PendingIntent GetLazyAlarmPendingIntent()
         {
             if (null == _alarmIntent)
             {
@@ -33,17 +33,25 @@ namespace com.on.relax.your.eyes.droid
             return _alarmIntent;
         }
 
-        public void ScheduleSingleAlarm(long intervalMs)
+        public void ScheduleSingleAlarm(long nextAlarmInMs)
         {
             var alarmType = AlarmType.ElapsedRealtimeWakeup;
-            var nextAlarmAt = SystemClock.ElapsedRealtime() + intervalMs;
-            GetLazyAlarmManager().SetRepeating(alarmType, nextAlarmAt, intervalMs, GetLazyAlarmIntent());
-            //GetLazyAlarmManager().SetInexactRepeating(alarmType, nextAlarmAt, intervalMs, GetLazyAlarmIntent());
+            var nextAlarmAt = SystemClock.ElapsedRealtime() + nextAlarmInMs;
+            var manager = GetLazyAlarmManager();
+            var pendingIntent = GetLazyAlarmPendingIntent();
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.M) {
+                manager.SetExactAndAllowWhileIdle(alarmType, nextAlarmAt, pendingIntent);
+            } else if (Build.VERSION.SdkInt >= BuildVersionCodes.Kitkat) {
+                manager.SetExact(alarmType, nextAlarmAt, pendingIntent);
+            } else {
+                manager.Set(alarmType, nextAlarmAt, pendingIntent);
+            }
+            //GetLazyAlarmManager().SetInexactRepeating(alarmType, nextAlarmAt, intervalMs, GetLazyAlarmPendingIntent());
         }
 
         public void CancelSingleAlarm()
         {
-            GetLazyAlarmIntent().Cancel();
+            GetLazyAlarmPendingIntent().Cancel();
             _alarmIntent = null;
         }
     }

--- a/com.on.relax.your.eyes.droid/EyesGymReceiver.cs
+++ b/com.on.relax.your.eyes.droid/EyesGymReceiver.cs
@@ -2,7 +2,7 @@
 using Android.App;
 using Android.Content;
 using com.on.relax.your.eyes.logic;
-using com.@on.relax.your.eyes.xam.Localization;
+using com.on.relax.your.eyes.xam.Localization;
 using Debug = System.Diagnostics.Debug;
 
 namespace com.on.relax.your.eyes.droid
@@ -33,10 +33,18 @@ namespace com.on.relax.your.eyes.droid
             }
             
             var extraAsEnum = (UserDialog)Enum.Parse(typeof(UserDialog), extra);
-            if(AcceptDialog == extraAsEnum)
+            switch (extraAsEnum)
             {
-                var mainActivityIntent = IntentFactory.GetStartIntent(context);
-                context.StartActivity(mainActivityIntent);
+                case AcceptDialog:
+                    //todo change state and then start activity
+                    var mainActivityIntent = IntentFactory.GetStartIntent(context);
+                    context.StartActivity(mainActivityIntent);
+                    break;
+                case PostponeDialog:
+                    var alarm = new AlarmImpl(new ContextWrapper(context.ApplicationContext));
+                    var nextAlarmInMs = 5000;
+                    alarm.ScheduleSingleAlarm(nextAlarmInMs);
+                    break;
             }
 
             CancelPending(context, intent, (int)extraAsEnum);

--- a/com.on.relax.your.eyes.droid/Notifications.cs
+++ b/com.on.relax.your.eyes.droid/Notifications.cs
@@ -60,7 +60,9 @@ namespace com.on.relax.your.eyes.droid
         public static void Cancel(Context context)
         {
             var notificationManager = (NotificationManager) context.GetSystemService(Context.NotificationService);
-            notificationManager.Cancel(NotificationId);
+
+            if (null != notificationManager)
+                notificationManager.Cancel(NotificationId);
         }
     }
 }

--- a/com.on.relax.your.eyes.logic/ISingleAlarm.cs
+++ b/com.on.relax.your.eyes.logic/ISingleAlarm.cs
@@ -2,7 +2,7 @@
 {
     public interface ISingleAlarm
     {
-        void ScheduleSingleAlarm(long intervalMs);
+        void ScheduleSingleAlarm(long nextAlarmInMs);
         void CancelSingleAlarm();
     }
 }

--- a/com.on.relax.your.eyes.uwp/MainPage.xaml.cs
+++ b/com.on.relax.your.eyes.uwp/MainPage.xaml.cs
@@ -10,7 +10,7 @@ namespace com.on.relax.your.eyes.uwp
             throw new System.NotImplementedException();
         }
 
-        public void ScheduleSingleAlarm(long intervalMs)
+        public void ScheduleSingleAlarm(long nextAlarmInMs)
         {
             throw new System.NotImplementedException();
         }

--- a/com.on.relax.your.eyes.xam/ApplicationState.cs
+++ b/com.on.relax.your.eyes.xam/ApplicationState.cs
@@ -30,17 +30,19 @@ namespace com.on.relax.your.eyes.xam
             var newState = sm.SwitchState(requested);
             if (newState != previous)
             {
+                var nextAlarmInMs = 15000;
                 switch (newState)
                 {
                     case State.On:
                         //pause to on will reschedule alarm
-                        alarmHandler.ScheduleSingleAlarm(5000);
+                        alarmHandler.ScheduleSingleAlarm(nextAlarmInMs);
                         break;
                     case State.Off:
                         alarmHandler.CancelSingleAlarm();
                         break;
                     case State.Pause:
                         //hold alarm: start counting current pause time, then reschedule the alarm to later time
+                        alarmHandler.CancelSingleAlarm();
                         break;
                     case State.ExerciseSuggested:
                         //show dialog to accept or postpone the exercise, hold alarm


### PR DESCRIPTION
problem: with SetInexactRepeating the Receiver got the alarm only when the app is running.
replaced it with SetExactAndAllowWhileIdle.

now works fine. user can schedule alarm and close the app.
on the other hand, the alarm is one-time, so i need to change the notification type.

user should not just skip the alarm. user should press one of the 2 proposed buttons: "postpone" leads to rescheduling (implemented). "start exercise" leads to opened app (to be implemented).